### PR TITLE
Update embedde graphics

### DIFF
--- a/blue-pill-examples/Cargo.toml
+++ b/blue-pill-examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 stm32f1xx-hal = { version = "0.5", features = ["rt", "stm32f103", "medium" ] } 
 panic-semihosting = "0.5"
-st7735-lcd = "0.6"
-embedded-graphics = "0.5"
+st7735-lcd = "0.7"
+embedded-graphics = "0.6"
 cortex-m = "0.6"
 cortex-m-rt = "0.6"

--- a/metro-m4-examples/Cargo.toml
+++ b/metro-m4-examples/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 [dev-dependencies]
 metro_m4 = "0.5"
 panic-halt = "0.2"
-st7735-lcd = "0.6"
-embedded-graphics = "0.5"
+st7735-lcd = "0.7"
+embedded-graphics = "0.6"


### PR DESCRIPTION
Hi, 

thanks for putting this example up, it really helped me to understand how embedded-graphics works.

I've updated the blue pill example to the latest 0.6 release of embedded-graphics and tested that it works fine using a 160x128 rgb tft display.

I also updated the metro-m4 example, but couldn't test it myself.